### PR TITLE
pass the test of float, but got "uninitialized constant Kernel::Foo (NameError)" with the latest mruby

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,37 @@
+# This workflow checks if mrubybind works with the latest mruby
+
+name: CI
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+
+      # Checks-out the repository under $GITHUB_WORKSPACE, so the job can access it
+      - uses: actions/checkout@v4
+
+      - name: Glone the latest mruby
+        run: git clone --depth 1 https://github.com/mruby/mruby
+
+      - name: Prepare mruby
+        run: |
+          cd mruby
+          rake -j4
+
+      - name: Test in test
+        run: |
+          cd ../test
+          MRUBY=../mruby make test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,5 +33,5 @@ jobs:
 
       - name: Test in test
         run: |
-          cd ../test
+          cd test
           MRUBY=../mruby make test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
 
       # Checks-out the repository under $GITHUB_WORKSPACE, so the job can access it
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Glone the latest mruby
         run: git clone --depth 1 https://github.com/mruby/mruby

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@
 /test/module
 /test/wrong_type
 /test/wrong_arg_num
+
+/test/*.exe

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ This fork of mrubybind is under continuous integration at GitHub Actions:
 | bool                | TrueClass or FalseClass |
 | void*               | Object                  |
 
-See [mrubybind.h](https://github.com/ktaobo/mrubybind/blob/master/mrubybind.h).
+See mrubybind.h .
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,17 @@ mrubybind - Binding library for mruby/C++
 mrubybind automatically creates C function/class-method binder for [mruby](https://github.com/mruby/mruby),
 using C++ template partial specialization.
 
+Fork history:
+https://github.com/ktaobo/mrubybind (original, not exist now) --->
+https://github.com/skandhas/mrubybind (copy of original) --->
+https://github.com/mdorier/mrubybind (using variadic templates) --->
+https://github.com/t-nissie/mrubybind (this fork)
+
+See also: https://gist.github.com/t-nissie/a2eeabc18c4cd5b010f89890ff30dc5f
+
+This fork of mrubybind is under continuous integration at GitHub Actions:
+[![CI](https://github.com/t-nissie/mrubybind/workflows/CI/badge.svg)](https://github.com/t-nissie/mrubybind/actions)
+
 ## Usage
 
 ### How to use mrubybind in your project

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Fork history:
 https://github.com/ktaobo/mrubybind (original, not exist now) --->
 https://github.com/skandhas/mrubybind (copy of original) --->
 https://github.com/mdorier/mrubybind (using variadic templates) --->
-https://github.com/t-nissie/mrubybind (this fork)
+https://github.com/t-nissie/mrubybind (this fork fixed for [the commit 9c9be44a98 of mruby](https://github.com/mruby/mruby/commit/9c9be44a98))
 
 See also: https://gist.github.com/t-nissie/a2eeabc18c4cd5b010f89890ff30dc5f
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ This fork of mrubybind is under continuous integration at GitHub Actions:
 2. Include "mrubybind.h"
 3. Use `MrubyBind` instance to bind C function/class-method to mruby.
 
+You can ask DeepWiki:
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/t-nissie/mrubybind)
+
 ## Examples
 
 ### Bind C function and call it from mruby

--- a/mrubybind.cc
+++ b/mrubybind.cc
@@ -61,12 +61,6 @@ void MrubyBind::Initialize() {
   arena_index_ = mrb_gc_arena_save(mrb_);
 }
 
-struct RClass* MrubyBind::GetClass(const char* class_name) {
-  mrb_value mod = mrb_obj_value(mod_);
-  mrb_value klass_v = mrb_const_get(mrb_, mod, mrb_intern_cstr(mrb_, class_name));
-  return mrb_class_ptr(klass_v);
-}
-
 void MrubyBind::BindInstanceMethod(
     const char* class_name, const char* method_name,
     mrb_value original_func_v,
@@ -77,7 +71,7 @@ void MrubyBind::BindInstanceMethod(
     mrb_symbol_value(method_name_s),  // 1: method name
   };
   struct RProc* proc = mrb_proc_new_cfunc_with_env(mrb_, binder_func, 2, env);
-  struct RClass* klass = GetClass(class_name);
+  struct RClass* klass = mrb_class_get(mrb_, class_name);
   mrb_method_t method;
   MRB_METHOD_FROM_PROC(method, proc);
   mrb_define_method_raw(mrb_, klass, method_name_s, method);

--- a/mrubybind.h
+++ b/mrubybind.h
@@ -471,7 +471,7 @@ public:
   template <class Func>
   void bind_class(const char* class_name, Func new_func_ptr) {
     struct RClass *tc = mrb_define_class(mrb_, class_name, mrb_->object_class);
-    MRB_SET_INSTANCE_TT(tc, MRB_TT_DATA);
+    MRB_SET_INSTANCE_TT(tc, MRB_TT_CDATA);
     BindInstanceMethod(class_name, "initialize",
                        mrb_cptr_value(mrb_, (void*)new_func_ptr),
                        ClassBinder<Func>::ctor);
@@ -498,7 +498,7 @@ public:
       mrb_symbol_value(method_name_s),          // 1: method name
     };
     struct RProc* proc = mrb_proc_new_cfunc_with_env(mrb_, Binder<Method>::call, 2, env);
-    struct RClass* klass = GetClass(class_name);
+    struct RClass* klass = mrb_class_get(mrb_, class_name);
     mrb_method_t method;
     MRB_METHOD_FROM_PROC(method, proc);
     mrb_define_class_method_raw(mrb_, klass, method_name_s, method);
@@ -506,9 +506,6 @@ public:
 
 private:
   void Initialize();
-
-  // Returns mruby class under a module.
-  struct RClass* GetClass(const char* class_name);
 
   // Utility for binding instance method.
   void BindInstanceMethod(const char* class_name, const char* method_name,

--- a/test/Makefile
+++ b/test/Makefile
@@ -21,7 +21,7 @@ test:	$(EXES)
 %.o:	%.cc
 	g++ -c -o $@ $(INC) $(CXXFLAGS) $<
 
-mrubybind.o:	$(MRUBYBIND_SRCDIR)/mrubybind.cc
+mrubybind.o:	$(MRUBYBIND_SRCDIR)/mrubybind.cc $(MRUBYBIND_SRCDIR)/mrubybind.h
 	g++ -c -o $@ $(INC) $(CXXFLAGS) $<
 
 void:	void.o $(MRUBYBIND_OBJ)

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,5 +1,5 @@
 
-INC=-I $(MRUBY)/include -I ..
+INC=-I $(MRUBY)/build/host/include -I ..
 LIB=-L $(MRUBY)/build/host/lib -lmruby
 
 MRUBYBIND_SRCDIR=..

--- a/test/test.sh
+++ b/test/test.sh
@@ -50,8 +50,8 @@ Foo::dtor()'
 run module 'modfunc called: 1234'
 
 # Failure cases
-fail wrong_type "can't convert String into Fixnum, argument 1(1111) (TypeError)"
-fail wrong_arg_num "'square': wrong number of arguments (2 for 1) (ArgumentError)"
+fail wrong_type "#<TypeError: can't convert String into Fixnum, argument 1(1111)>"
+fail wrong_arg_num "#<ArgumentError: 'square': wrong number of arguments (2 for 1)>"
 
 ################################################################
 # All tests succeeded.

--- a/test/test.sh
+++ b/test/test.sh
@@ -40,7 +40,7 @@ function fail() {
 
 run void 'dummy called'
 run int '1234321'
-run float '408'
+run float '408.0'
 run string '* Hello, mruby! *'
 run cptr 'cptr test'
 run class 'Foo::ctor(123)

--- a/test/test.sh
+++ b/test/test.sh
@@ -50,8 +50,8 @@ Foo::dtor()'
 run module 'modfunc called: 1234'
 
 # Failure cases
-fail wrong_type "TypeError: can't convert String into Fixnum, argument 1(1111)"
-fail wrong_arg_num "ArgumentError: 'square': wrong number of arguments (2 for 1)"
+fail wrong_type "can't convert String into Fixnum, argument 1(1111) (TypeError)"
+fail wrong_arg_num "'square': wrong number of arguments (2 for 1) (ArgumentError)"
 
 ################################################################
 # All tests succeeded.


### PR DESCRIPTION
Dear Dr. Dorier,

Thank you for your simplification in mrubybind using C++14 variadic templates.
It is great!

I want to use mrubybind with the latest mruby.
I fixed test/test.sh to pass the test of float.
However, I got an error of "uninitialized constant Kernel::Foo (NameError)" as
```
$ git clone https://github.com/mruby/mruby.git
$ cd mruby
$ rake
$ cd ..
$ git clone https://github.com/mdorier/mrubybind.git
$ cd mrubybind/test
$ MRUBY=../../mruby make test
          :
Testing class ... (unknown):0: uninitialized constant Kernel::Foo (NameError)
[ERROR] exit status is not 0 [134]
          :
```
Can you please fix it?

A change in bind_class() in mrubybind.h
from  `MRB_SET_INSTANCE_TT(tc, MRB_TT_DATA);`
to      ` MRB_SET_INSTANCE_TT(tc, MRB_TT_CDATA);`
could not cure the error.

Sincerely,
-- Takeshi Nishimatsu

